### PR TITLE
Pick root directory of archive

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var tar = require('tar-stream');
 
-module.exports = function (filename) {
+module.exports = function (filename, rootDir) {
 	if (!filename) {
 		throw new gutil.PluginError('gulp-tar', '`filename` required');
 	}
+	rootDir = rootDir ? (rootDir + path.sep) : '';
 
 	var firstFile;
 	var pack = tar.pack();
@@ -27,7 +28,7 @@ module.exports = function (filename) {
 			firstFile = file;
 		}
 
-		var relativePath = file.path.replace(file.cwd + path.sep, '');
+		var relativePath = file.path.replace(file.cwd + path.sep + rootDir, '');
 		pack.entry({name: relativePath}, file.contents);
 		cb();
 	}, function (cb) {


### PR DESCRIPTION
This allows choosing which directory in the folder structure should be the root of the archive so that if you have:

```
build/
    output/
        file1.js
        file2.jpg
```

you can do

```
gulp.src('build/output/**/*')
    .pipe(tar('archive.tar', 'build/output'))
    .pipe(gulp.dest('dist'));
```

and have `archive.tar` contain only:

```
file1.js
file2.jpg
```

directly at the root level rather than with the whole local folder hierarchy.
