### PR TITLE
Unwanted creation of empty directories bug fixed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = function (filename) {
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
-			this.push(file);
 			return cb();
 		}
 


### PR DESCRIPTION
When `gulp-tar` to a destination directory different than the one of the source directory, empty directories are created along with the tar file.
