### PR TITLE
Pass modified date to tar file header

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = function (filename, options) {
 
 		archive.append(file.contents, objectAssign({
 			name: file.relative.replace(/\\/g, '/') + (file.isNull() ? '/' : ''),
-			mode: file.stat && file.stat.mode
+			mode: file.stat && file.stat.mode,
+			date: file.stat && file.stat.mtime ? file.stat.mtime : null
 		}, options || {}));
 
 		cb();


### PR DESCRIPTION
If `gulp-tar` is run multiple times on the same content the resulting tar will have different contents. This is because the default behavior of the `archiver` library is to use the current date if none have been provided for the entry header.

With this change the modified date from the file itself will be provided allowing for the same `tar` file to be consistently created from the same contents.