### PR TITLE
Update option passing to reflect the move from tar-stream to archiver

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (filename, opts) {
 	}
 
 	var firstFile;
-	var archive = archiver('tar');
+	var archive = archiver('tar', opts);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.relative === '') {
@@ -27,7 +27,7 @@ module.exports = function (filename, opts) {
 			name: file.relative.replace(/\\/g, '/') + (file.isNull() ? '/' : ''),
 			mode: file.stat && file.stat.mode,
 			date: file.stat && file.stat.mtime ? file.stat.mtime : null
-		}, opts));
+		}));
 
 		cb();
 	}, function (cb) {

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Filename for the output tar archive.
 
 Type: `object`
 
-Default file headers passed to [tar-stream](https://github.com/mafintosh/tar-stream).
+Default options passed to [archiver](https://github.com/archiverjs/node-archiver).
 
 
 ## License


### PR DESCRIPTION
Pass options to the Archiver constructor rather than to its `append` method, which doesn't support them.