### PR TITLE
Pass options to Archiver's constructor as well as its append method

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (filename, opts) {
 	}
 
 	var firstFile;
-	var archive = archiver('tar');
+	var archive = archiver('tar', opts);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.relative === '') {

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Filename for the output tar archive.
 
 Type: `object`
 
-Default file headers passed to [tar-stream](https://github.com/mafintosh/tar-stream).
+Default options passed to [Archiver](https://github.com/archiverjs/node-archiver)'s [constructor](https://archiverjs.com/docs/Archiver.html) and merged into the [data](https://archiverjs.com/docs/global.html#TarEntryData) passed to its [`append`](https://archiverjs.com/docs/Archiver.html#append) method.
 
 
 ## License


### PR DESCRIPTION
Currently, [`append` options](https://archiverjs.com/docs/global.html#TarEntryData) can be supplied, which are merged into gulp-tar's options, but there's no way to pass [options](https://archiverjs.com/docs/global.html#TarOptions) to the Archiver constructor.

I guess the options are:

### 1) separate options

```javascript
tar(filename, archiverOptions, appendOptions)
tar(filename, appendOptions, archiverOptions)
```

### 2) a key for each option

```javascript
tar(filename, { archiver: { ... }, append: { ... } })
```

### 3) a single object

```javascript
tar(filename, { prefix: 'package', gzip: true })
```

This PR implements the third option since the keys are disjoint.